### PR TITLE
Fix resize bug and console error

### DIFF
--- a/assets/js/sengab.js
+++ b/assets/js/sengab.js
@@ -33,10 +33,18 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
             //  Check whether the element is scaled
             function detectScale(x) {
-                const itemTransform = getComputedStyle(x).getPropertyValue('transform');
-                const itemMatrex = itemTransform.match(/^matrix\((.+)\)$/)[1].split(', ');
-                let itemScaleY = itemMatrex[3];
-
+                let itemScaleY;
+                if( 'none' !==  getComputedStyle(x)) {
+                    if( 'none' !==   getComputedStyle(x).getPropertyValue('transform')) {
+                        const itemTransform = getComputedStyle(x).getPropertyValue('transform');
+                        const itemMatrex = itemTransform.match(/^matrix\((.+)\)$/)[1].split(', ');
+                        itemScaleY = itemMatrex[3];
+                    }else {
+                        itemScaleY = 1;
+                    }
+                }else {
+                    itemScaleY = 1;
+                }
                 return itemScaleY;
             }
             

--- a/assets/js/sengab.js
+++ b/assets/js/sengab.js
@@ -73,7 +73,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
             detectWindowsEvents(['load','scroll','resize'], ()=> {
                 detectWindowsEvents(['resize'], ()=> {
-                    sengabPos = getpos();
+                    sengabPos = getpos(sengab);
                 })
                 winHeight = window.innerHeight;
                 sengabHeight = sengab.clientHeight;


### PR DESCRIPTION
1- Fix the resize bug by adding the missing Parameters.
2- Fix the console error occurs when there is no element scale or when the animation class is missing.