### PR TITLE
Fix the resize bug and the console error

### DIFF
--- a/assets/js/sengab.js
+++ b/assets/js/sengab.js
@@ -33,10 +33,18 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
             //  Check whether the element is scaled
             function detectScale(x) {
-                const itemTransform = getComputedStyle(x).getPropertyValue('transform');
-                const itemMatrex = itemTransform.match(/^matrix\((.+)\)$/)[1].split(', ');
-                let itemScaleY = itemMatrex[3];
-
+                let itemScaleY;
+                if( 'none' !==  getComputedStyle(x)) {
+                    if( 'none' !==   getComputedStyle(x).getPropertyValue('transform')) {
+                        const itemTransform = getComputedStyle(x).getPropertyValue('transform');
+                        const itemMatrex = itemTransform.match(/^matrix\((.+)\)$/)[1].split(', ');
+                        itemScaleY = itemMatrex[3];
+                    }else {
+                        itemScaleY = 1;
+                    }
+                }else {
+                    itemScaleY = 1;
+                }
                 return itemScaleY;
             }
             
@@ -73,7 +81,7 @@ window.addEventListener('DOMContentLoaded', ()=>{
 
             detectWindowsEvents(['load','scroll','resize'], ()=> {
                 detectWindowsEvents(['resize'], ()=> {
-                    sengabPos = getpos();
+                    sengabPos = getpos(sengab);
                 })
                 winHeight = window.innerHeight;
                 sengabHeight = sengab.clientHeight;


### PR DESCRIPTION
1- Fix the resize bug by adding the missing parameter value.
2- Fix the error occures when the element is not scaled or when an animation class is missing.